### PR TITLE
Fix simple-bot-manager loading crash

### DIFF
--- a/bp_ort/src/bots/simple_bot_manager.rs
+++ b/bp_ort/src/bots/simple_bot_manager.rs
@@ -172,9 +172,8 @@ pub fn check_player_amount(plugin: &super::Bots, token: EngineToken) -> Result<(
         // a bit of a hack to work around weird issues bots can encounter during the limbo where loading is still happening but everything is marked as ready
         if curr_level == LOBBY {
             // remove bots from the lobby
-            kick_player(engine_funcs);
+            //kick_player(engine_funcs);
             manager_data.active = false;
-
             return Ok(());
         } else if manager_data.active
             || (0..32)


### PR DESCRIPTION
Fixes some crashing issues I encountered involving `simple-bot-manager` crashing during level transitions. 

You should be able to replicate the crash by going into a private match with `bot_manager_enabled` set to 1 and `bot_manager_target/max` set to 12, then load the Attrition gamemode on any map, exit to the lobby then load into a new map. While it was loading you should get a `EXCEPTION_ACCESS_VIOLATION`, though it is possible this is a linux specific issue or simply a me issue. 

I believe the method call that specifically that caused the crash was `server_funcs.client_fully_connected` at `440` in `bp-ort/src/bots/mod.rs`.

I was able to solve this issue by simply skipping execution of `check_player_amount` in conditions where the issue occured, which means that they only spawn in after at least 1 human player has spawned(this only needs to occur once per match, which is basically guaranteed) and bots are kicked if the current level is `mp_lobby` to avoid bots existing outside of the level they were spawned in originally.

let me know if you have any issues, I rarely write rust code nor do I really know what I am doing so there are likely a few oversights on my part.